### PR TITLE
Update requirements_llamaindex.txt

### DIFF
--- a/sparrow-ml/llm/requirements_llamaindex.txt
+++ b/sparrow-ml/llm/requirements_llamaindex.txt
@@ -1,4 +1,5 @@
 llama-index==0.10.23
+llama-index-core==0.10.23.post1
 llama-index-embeddings-langchain==0.1.2
 llama-index-llms-ollama==0.1.2
 llama-index-vector-stores-weaviate==0.1.4


### PR DESCRIPTION
Need to set the version of `llama-index-core` as `0.10.23.post1`, otherwise `0.10.68.post1` would be installed, which will cause the issue `ImportError: llama-index-readers-file package not found`. 
(The root cause: in the version `0.10.68.post1`, there is an unresolvable import of `llama_index.readers.file.PandasExcelReader` in `llama_index/core/readers/file/base.py`)

@abaranovskis-redsamurai might you help to check your local version for `llama-index-core`? That version might be better.
Before the change:
```llama-index                             0.10.23
llama-index-agent-openai                0.1.7
llama-index-cli                         0.1.13
llama-index-core                        0.10.68.post1
llama-index-embeddings-clip             0.1.4
llama-index-embeddings-huggingface      0.1.4
llama-index-embeddings-langchain        0.1.2
llama-index-embeddings-openai           0.1.11
llama-index-indices-managed-llama-cloud 0.1.6
llama-index-legacy                      0.9.48.post3
llama-index-llms-ollama                 0.1.2
llama-index-llms-openai                 0.1.31
llama-index-multi-modal-llms-ollama     0.1.3
llama-index-multi-modal-llms-openai     0.1.9
llama-index-program-openai              0.1.7
llama-index-question-gen-openai         0.1.3
llama-index-readers-file                0.1.12
llama-index-readers-llama-parse         0.1.6
llama-index-vector-stores-qdrant        0.1.4
llama-index-vector-stores-weaviate      0.1.4
```

=>
After the change:

```llama-index                             0.10.23
llama-index-agent-openai                0.1.7
llama-index-cli                         0.1.13
llama-index-core                        0.10.23.post1
llama-index-embeddings-clip             0.1.4
llama-index-embeddings-huggingface      0.1.4
llama-index-embeddings-langchain        0.1.2
llama-index-embeddings-openai           0.1.11
llama-index-indices-managed-llama-cloud 0.1.6
llama-index-legacy                      0.9.48.post3
llama-index-llms-ollama                 0.1.2
llama-index-llms-openai                 0.1.12
llama-index-multi-modal-llms-ollama     0.1.3
llama-index-multi-modal-llms-openai     0.1.9
llama-index-program-openai              0.1.6
llama-index-question-gen-openai         0.1.3
llama-index-readers-file                0.1.12
llama-index-readers-llama-parse         0.1.6
llama-index-vector-stores-qdrant        0.1.4
llama-index-vector-stores-weaviate      0.1.4
```