### PR TITLE
Update api inference in ocr.py

### DIFF
--- a/sparrow-data/ocr/routers/ocr.py
+++ b/sparrow-data/ocr/routers/ocr.py
@@ -91,7 +91,7 @@ async def inference(file: UploadFile = File(None),
 
             if content_type in ["image/jpeg", "image/jpg", "image/png"]:
                 doc = Image.open(BytesIO(response.read()))
-            elif content_type == "application/octet-stream":
+            elif content_type in ["application/pdf", "application/octet-stream"]:
                 pdf_bytes = response.read()
                 pages = convert_from_bytes(pdf_bytes, 300)
                 doc = pages[0]


### PR DESCRIPTION
update in /inference api in OCR, to take the content type application/pdf, to validate the content type when image_url from aws S3 contains content type as application/pdf,