### PR TITLE
Played with agents API - small usability related suggestion

### DIFF
--- a/sparrow-ml/agents/api.py
+++ b/sparrow-ml/agents/api.py
@@ -170,10 +170,10 @@ if __name__ == "__main__":
 
     # Add argument parsing for port
     parser = argparse.ArgumentParser()
-    parser.add_argument('--port', type=int, default=8001)
+    parser.add_argument('--port', type=int, default=8003)
     args = parser.parse_args()
 
-    uvicorn.run("api:app", host="0.0.0.0", port=8001, reload=True)
+    uvicorn.run("api:app", host="0.0.0.0", port=args.port, reload=True)
 
     # http://127.0.0.1:8001/docs
 


### PR DESCRIPTION
Make use of --port argument value
Suggested to use 8003 to coexist with ocr api.