### PR TITLE
feat: add LiteLLM AI gateway as a vision-LLM backend

### DIFF
--- a/sparrow-data/parse/README.md
+++ b/sparrow-data/parse/README.md
@@ -33,10 +33,17 @@ To run with Ollama on Linux/Windows:
 pip install sparrow-parse
 ```
 
+To run with LiteLLM (AI gateway over 100+ hosted providers, no separate proxy server required):
+
+```bash
+pip install sparrow-parse[litellm]
+```
+
 **Additional Requirements:**
 - For PDF processing: `brew install poppler` (macOS) or `apt-get install poppler-utils` (Linux)
 - For MLX backend: Apple Silicon Mac required
 - For Hugging Face: Valid HF token with GPU access
+- For LiteLLM backend: provider-specific API keys via env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) per https://docs.litellm.ai/docs/providers
 
 ### Basic Usage
 
@@ -92,6 +99,30 @@ config = {
     "model_name": "mistral-small3.2:24b-instruct-2506-q8_0"
 }
 ```
+
+#### LiteLLM Backend (AI Gateway, 100+ hosted providers)
+Embedded LiteLLM SDK. One backend, many upstream providers (OpenAI, Anthropic,
+Vertex AI, Bedrock, Azure, Groq, Mistral, ...). Specify the model with the
+standard LiteLLM provider-prefixed name. Credentials are picked up from the
+matching provider env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`AWS_ACCESS_KEY_ID`, ...) unless `api_key` / `api_base` are passed explicitly.
+Install with `pip install sparrow-parse[litellm]`.
+
+```python
+config = {
+    "method": "litellm",
+    "model_name": "anthropic/claude-3-5-sonnet-20241022",
+    # Optional, leave unset to use ANTHROPIC_API_KEY env var:
+    # "api_key": "sk-ant-...",
+    # "api_base": "https://your-foundry-endpoint/anthropic",
+    # Optional litellm.completion kwargs. drop_params=True is the default
+    # and silently strips kwargs unsupported on the upstream provider.
+    # "litellm_kwargs": {"num_retries": 3, "drop_params": True},
+}
+```
+
+See https://docs.litellm.ai/docs/providers for the full list of supported
+provider prefixes.
 
 #### Hugging Face Backend
 ```python

--- a/sparrow-data/parse/setup.py
+++ b/sparrow-data/parse/setup.py
@@ -41,6 +41,9 @@ setup(
                 "numpy",
                 "vllm==0.19.0; sys_platform == 'linux'",
             ],
+            "litellm": [
+                "litellm>=1.60,<1.85",
+            ],
             "all": [
                 "transformers==5.1.0",
                 "torch==2.11.0",
@@ -49,6 +52,7 @@ setup(
                 "mlx==0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
                 "mlx-vlm==0.4.4; sys_platform == 'darwin' and platform_machine == 'arm64'",
                 "vllm==0.19.0; sys_platform == 'linux'",
+                "litellm>=1.60,<1.85",
             ],
         },
     entry_points={

--- a/sparrow-data/parse/sparrow_parse/test_litellm_inference.py
+++ b/sparrow-data/parse/sparrow_parse/test_litellm_inference.py
@@ -1,0 +1,290 @@
+"""Unit tests for the LiteLLM vision-LLM backend.
+
+Tests run without external dependencies by mocking ``litellm.completion``.
+Live integration is exercised via a separate scratch script (not part of
+the suite).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sparrow_parse.vlmb.litellm_inference import (
+    LiteLLMInference,
+    _file_to_data_uri,
+)
+from sparrow_parse.vlmb.inference_factory import InferenceFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_completion(content: str) -> SimpleNamespace:
+    """Build a mock OpenAI-shaped litellm.completion return value."""
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+def _make_temp_image() -> str:
+    """Write a tiny PNG-like blob to a temp file and return the path."""
+    fd, path = tempfile.mkstemp(suffix=".png")
+    with os.fdopen(fd, "wb") as fh:
+        # Minimal 1x1 PNG byte signature; content doesn't matter for tests.
+        fh.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMInit(unittest.TestCase):
+    def test_drop_params_default_on(self):
+        backend = LiteLLMInference("anthropic/claude-3-5-sonnet-20241022")
+        self.assertIs(backend.default_kwargs.get("drop_params"), True)
+
+    def test_drop_params_can_be_disabled(self):
+        backend = LiteLLMInference(
+            "anthropic/claude-3-5-sonnet-20241022",
+            litellm_kwargs={"drop_params": False},
+        )
+        self.assertIs(backend.default_kwargs.get("drop_params"), False)
+
+    def test_user_kwargs_merged_with_default(self):
+        backend = LiteLLMInference(
+            "openai/gpt-4o",
+            litellm_kwargs={"num_retries": 3, "timeout": 120},
+        )
+        self.assertEqual(backend.default_kwargs.get("num_retries"), 3)
+        self.assertEqual(backend.default_kwargs.get("timeout"), 120)
+        # default still preserved
+        self.assertIs(backend.default_kwargs.get("drop_params"), True)
+
+    def test_call_kwargs_omits_unset_credentials(self):
+        backend = LiteLLMInference("openai/gpt-4o")
+        kwargs = backend._call_kwargs()
+        self.assertNotIn("api_key", kwargs)
+        self.assertNotIn("api_base", kwargs)
+
+    def test_call_kwargs_includes_provided_credentials(self):
+        backend = LiteLLMInference(
+            "openai/gpt-4o",
+            api_key="sk-test",
+            api_base="https://example.invalid/v1",
+        )
+        kwargs = backend._call_kwargs()
+        self.assertEqual(kwargs["api_key"], "sk-test")
+        self.assertEqual(kwargs["api_base"], "https://example.invalid/v1")
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryRegistration(unittest.TestCase):
+    def test_factory_returns_litellm_backend(self):
+        factory = InferenceFactory(
+            {"method": "litellm", "model_name": "openai/gpt-4o-mini"}
+        )
+        instance = factory.get_inference_instance()
+        self.assertIsInstance(instance, LiteLLMInference)
+        self.assertEqual(instance.model_name, "openai/gpt-4o-mini")
+
+    def test_factory_passes_through_credentials(self):
+        factory = InferenceFactory(
+            {
+                "method": "litellm",
+                "model_name": "anthropic/claude-3-5-sonnet-20241022",
+                "api_key": "sk-test",
+                "api_base": "https://example.invalid/v1",
+                "litellm_kwargs": {"num_retries": 5},
+            }
+        )
+        instance = factory.get_inference_instance()
+        self.assertEqual(instance.api_key, "sk-test")
+        self.assertEqual(instance.api_base, "https://example.invalid/v1")
+        self.assertEqual(instance.default_kwargs["num_retries"], 5)
+
+
+# ---------------------------------------------------------------------------
+# inference() — mode handling
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceModes(unittest.TestCase):
+    def test_static_mode_returns_sample_json(self):
+        backend = LiteLLMInference("openai/gpt-4o-mini")
+        result = backend.inference([{"text_input": "ignored"}], mode="static")
+        self.assertEqual(len(result), 1)
+        # Sample JSON has a 'table' key per inference_base.get_simple_json
+        self.assertIn("table", json.loads(result[0]))
+
+    def test_empty_input_raises(self):
+        backend = LiteLLMInference("openai/gpt-4o-mini")
+        with self.assertRaises(ValueError):
+            backend.inference([])
+
+    def test_text_only_dispatch(self):
+        backend = LiteLLMInference("openai/gpt-4o-mini")
+        with patch(
+            "litellm.completion",
+            return_value=_mock_completion('{"answer": "4"}'),
+        ) as mock:
+            result = backend.inference(
+                [{"text_input": "what is 2+2?", "file_path": None}]
+            )
+        self.assertEqual(len(result), 1)
+        # Result is the cleaned/parsed JSON
+        self.assertEqual(json.loads(result[0]), {"answer": "4"})
+        # litellm.completion was called once with the text content as a string,
+        # confirming the text-only path was taken (not the image path).
+        kwargs = mock.call_args.kwargs
+        self.assertEqual(kwargs["model"], "openai/gpt-4o-mini")
+        self.assertEqual(
+            kwargs["messages"][0]["content"], "what is 2+2?"
+        )
+        self.assertIs(kwargs["drop_params"], True)
+
+
+# ---------------------------------------------------------------------------
+# Image dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestImageInference(unittest.TestCase):
+    def test_image_request_uses_data_uri(self):
+        backend = LiteLLMInference("anthropic/claude-3-5-sonnet-20241022")
+        img = _make_temp_image()
+        try:
+            with patch(
+                "litellm.completion",
+                return_value=_mock_completion('[{"name": "test"}]'),
+            ) as mock:
+                results = backend.inference(
+                    [
+                        {
+                            "file_path": [img],
+                            "text_input": "extract names as JSON list",
+                        }
+                    ]
+                )
+            self.assertEqual(len(results), 1)
+            kwargs = mock.call_args.kwargs
+            content_blocks = kwargs["messages"][0]["content"]
+            self.assertEqual(content_blocks[0]["type"], "text")
+            self.assertEqual(content_blocks[0]["text"], "extract names as JSON list")
+            self.assertEqual(content_blocks[1]["type"], "image_url")
+            url = content_blocks[1]["image_url"]["url"]
+            self.assertTrue(url.startswith("data:image/png;base64,"))
+        finally:
+            os.unlink(img)
+
+    def test_missing_image_skipped(self):
+        backend = LiteLLMInference("openai/gpt-4o-mini")
+        with patch("litellm.completion") as mock:
+            results = backend.inference(
+                [
+                    {
+                        "file_path": ["/nonexistent/path/that/does/not/exist.png"],
+                        "text_input": "extract",
+                    }
+                ]
+            )
+        # No file means no upstream call and no result
+        self.assertEqual(results, [])
+        mock.assert_not_called()
+
+    def test_image_failure_continues_with_other_files(self):
+        backend = LiteLLMInference("openai/gpt-4o-mini")
+        img1 = _make_temp_image()
+        img2 = _make_temp_image()
+        try:
+            # First call fails, second succeeds
+            with patch(
+                "litellm.completion",
+                side_effect=[
+                    Exception("network blip"),
+                    _mock_completion('{"ok": true}'),
+                ],
+            ):
+                results = backend.inference(
+                    [
+                        {"file_path": [img1, img2], "text_input": "extract"},
+                    ]
+                )
+            self.assertEqual(len(results), 1)
+            self.assertEqual(json.loads(results[0]), {"ok": True})
+        finally:
+            os.unlink(img1)
+            os.unlink(img2)
+
+
+# ---------------------------------------------------------------------------
+# process_response — JSON cleanup parity with sibling backends
+# ---------------------------------------------------------------------------
+
+
+class TestProcessResponse(unittest.TestCase):
+    def setUp(self):
+        self.backend = LiteLLMInference("openai/gpt-4o-mini")
+
+    def test_strips_markdown_code_fence(self):
+        raw = '```json\n{"a": 1}\n```'
+        out = self.backend.process_response(raw)
+        self.assertEqual(json.loads(out), {"a": 1})
+
+    def test_extracts_embedded_json_array(self):
+        raw = 'Here you go:\n[{"name": "Alice"}, {"name": "Bob"}]\nThanks.'
+        out = self.backend.process_response(raw)
+        self.assertEqual(
+            json.loads(out), [{"name": "Alice"}, {"name": "Bob"}]
+        )
+
+    def test_returns_text_when_not_json(self):
+        raw = "Plain text response"
+        self.assertEqual(self.backend.process_response(raw), raw)
+
+
+# ---------------------------------------------------------------------------
+# data URI helper
+# ---------------------------------------------------------------------------
+
+
+class TestDataUri(unittest.TestCase):
+    def test_data_uri_round_trip(self):
+        path = _make_temp_image()
+        try:
+            uri = _file_to_data_uri(path)
+            self.assertTrue(uri.startswith("data:image/png;base64,"))
+            encoded = uri.split(",", 1)[1]
+            with open(path, "rb") as fh:
+                expected = fh.read()
+            self.assertEqual(base64.b64decode(encoded), expected)
+        finally:
+            os.unlink(path)
+
+    def test_data_uri_falls_back_for_unknown_extension(self):
+        fd, path = tempfile.mkstemp(suffix=".weirdext")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\x00\x01\x02")
+        try:
+            uri = _file_to_data_uri(path)
+            # Falls back to image/png when mimetype can't be guessed
+            self.assertTrue(uri.startswith("data:image/png;base64,"))
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sparrow-data/parse/sparrow_parse/vlmb/inference_factory.py
+++ b/sparrow-data/parse/sparrow_parse/vlmb/inference_factory.py
@@ -19,6 +19,14 @@ class InferenceFactory:
         elif self.config["method"] == "vllm":
             from sparrow_parse.vlmb.vllm_inference import VLLMInference
             return VLLMInference(model_name=self.config["model_name"])
+        elif self.config["method"] == "litellm":
+            from sparrow_parse.vlmb.litellm_inference import LiteLLMInference
+            return LiteLLMInference(
+                model_name=self.config["model_name"],
+                api_key=self.config.get("api_key"),
+                api_base=self.config.get("api_base"),
+                litellm_kwargs=self.config.get("litellm_kwargs"),
+            )
         else:
             raise ValueError(f"Unknown method: {self.config['method']}")
 

--- a/sparrow-data/parse/sparrow_parse/vlmb/litellm_inference.py
+++ b/sparrow-data/parse/sparrow_parse/vlmb/litellm_inference.py
@@ -1,0 +1,238 @@
+"""LiteLLM AI Gateway inference backend.
+
+Routes every inference call through ``litellm.completion`` so a single Sparrow
+backend can extract from images using OpenAI, Anthropic, Vertex AI, Bedrock,
+Azure, Cohere, Mistral, Groq, and 90+ other vision-capable providers without
+adding each SDK separately. The model is selected via the standard LiteLLM
+provider-prefixed name (``anthropic/claude-3-5-sonnet-20241022``,
+``vertex_ai/gemini-1.5-pro``, ``bedrock/anthropic.claude-3-5-sonnet-...``,
+``azure/gpt-4o``, ``openai/gpt-4o``, ...) and credentials are resolved
+either from provider-specific environment variables (``ANTHROPIC_API_KEY``,
+``OPENAI_API_KEY``, ``AWS_ACCESS_KEY_ID``, ...) or from the optional
+``api_key`` / ``api_base`` passed to the backend.
+
+This is the *embedded* SDK form of LiteLLM. Sparrow imports the litellm
+Python package directly. It does not require running a separate LiteLLM proxy
+server.
+
+``drop_params=True`` is enabled by default so kwargs that some providers
+reject (``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini,
+Bedrock; ``response_format`` on Bedrock; etc.) are silently dropped instead
+of raising ``UnsupportedParamsError``. Override via ``litellm_kwargs``.
+"""
+
+import base64
+import json
+import mimetypes
+import os
+import re
+
+from sparrow_parse.vlmb.inference_base import ModelInference
+
+
+class LiteLLMInference(ModelInference):
+    """Vision-LLM backend that delegates to ``litellm.completion``."""
+
+    def __init__(self, model_name, api_key=None, api_base=None, litellm_kwargs=None):
+        """Initialize the LiteLLM inference backend.
+
+        :param model_name: LiteLLM provider-prefixed model id, for example
+            ``anthropic/claude-3-5-sonnet-20241022`` or
+            ``vertex_ai/gemini-1.5-pro``. See https://docs.litellm.ai/docs/providers.
+        :param api_key: Optional API key. When unset, LiteLLM resolves the
+            provider-specific key from environment variables.
+        :param api_base: Optional API base URL, only needed for OpenAI-compatible
+            custom endpoints (private LiteLLM proxies, Azure deployments, etc.).
+        :param litellm_kwargs: Optional dict of extra kwargs forwarded to every
+            ``litellm.completion`` call. ``drop_params=True`` is set by default
+            and merged with anything passed here.
+        """
+        try:
+            import litellm  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "litellm is required for LiteLLMInference. "
+                'Install via `pip install "litellm>=1.60,<1.85"` '
+                'or `pip install "sparrow-parse[litellm]"`.'
+            ) from exc
+
+        self.model_name = model_name
+        self.api_key = api_key
+        self.api_base = api_base
+
+        merged = {"drop_params": True}
+        if litellm_kwargs and isinstance(litellm_kwargs, dict):
+            merged.update(litellm_kwargs)
+        self.default_kwargs = merged
+
+        print(f"LiteLLM initialized for model: {model_name}")
+
+    def process_response(self, output_text):
+        """Process and clean the model's raw output as JSON or markdown/text.
+
+        Mirrors the helper in ``ollama_inference.py`` / ``vllm_inference.py``
+        so callers see consistent output regardless of backend.
+        """
+        try:
+            if "```" in output_text:
+                json_start = output_text.find("```json")
+                if json_start != -1:
+                    content = output_text[json_start + 7:]
+                    json_end = content.rfind("```")
+                    if json_end != -1:
+                        content = content[:json_end].strip()
+                        formatted_json = json.loads(content)
+                        return json.dumps(formatted_json, indent=2, ensure_ascii=False)
+                else:
+                    return output_text
+
+            for pattern in [r"\[\s*\{.*\}\s*\]", r"\{.*\}"]:
+                matches = re.search(pattern, output_text, re.DOTALL)
+                if matches:
+                    potential_json = matches.group(0)
+                    try:
+                        formatted_json = json.loads(potential_json)
+                        return json.dumps(formatted_json, indent=2, ensure_ascii=False)
+                    except Exception:
+                        pass
+
+            formatted_json = json.loads(output_text.strip())
+            return json.dumps(formatted_json, indent=2, ensure_ascii=False)
+
+        except (json.JSONDecodeError, ValueError):
+            return output_text
+        except Exception:
+            return output_text
+
+    def inference(self, input_data, apply_annotation=False, ocr_callback=None, mode=None):
+        """Perform inference on input data using the configured LiteLLM model.
+
+        :param input_data: A list of dictionaries containing image file paths
+            and text inputs (same shape as the other vlmb backends).
+        :param apply_annotation: Optional flag to apply annotations to the
+            output. Not supported on the LiteLLM backend (ignored).
+        :param ocr_callback: Optional callback function to modify input data
+            before inference.
+        :param mode: Optional mode for inference. ``"static"`` returns a fixed
+            sample JSON for testing without an upstream call.
+        :return: List of processed model responses.
+        """
+        if not input_data or not isinstance(input_data, list) or len(input_data) == 0:
+            raise ValueError("input_data must be a non-empty list")
+
+        # Annotations are not supported on this backend.
+        apply_annotation = False
+
+        if mode == "static":
+            return [self.get_simple_json()]
+
+        is_text_only = input_data[0].get("file_path") is None
+
+        if is_text_only:
+            text = input_data[0]["text_input"]
+            return [self._generate_text_response(text)]
+
+        file_paths = self._extract_file_paths(input_data)
+        return self._process_images(file_paths, input_data, ocr_callback)
+
+    def _generate_text_response(self, text):
+        """Generate a text-only response."""
+        import litellm
+
+        try:
+            response = litellm.completion(
+                model=self.model_name,
+                messages=[{"role": "user", "content": text}],
+                **self._call_kwargs(),
+            )
+            content = response.choices[0].message.content or ""
+            print("Inference completed successfully")
+            return self.process_response(content)
+        except Exception as e:
+            print(f"Error during text inference: {e}")
+            raise
+
+    def _process_images(self, file_paths, input_data, ocr_callback):
+        """Process each image and produce a response."""
+        import litellm
+
+        results = []
+        for file_path in file_paths:
+            try:
+                if not os.path.exists(file_path):
+                    print(f"Warning: File does not exist: {file_path}")
+                    continue
+
+                text = self._prepare_text(file_path, input_data, ocr_callback)
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": text},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": _file_to_data_uri(file_path)},
+                            },
+                        ],
+                    }
+                ]
+
+                response = litellm.completion(
+                    model=self.model_name,
+                    messages=messages,
+                    **self._call_kwargs(),
+                )
+                raw = response.choices[0].message.content or ""
+                results.append(self.process_response(raw))
+                print(f"Inference completed successfully for: {file_path}")
+            except Exception as e:
+                print(f"Error processing image {file_path}: {e}")
+                # Match the resilience model used by ollama_inference: log the
+                # failure for one image and keep going, rather than aborting
+                # the whole batch.
+                continue
+
+        return results
+
+    def _call_kwargs(self):
+        """Build the kwargs dict for litellm.completion, including credentials."""
+        kwargs = dict(self.default_kwargs)
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        return kwargs
+
+    @staticmethod
+    def _prepare_text(file_path, input_data, ocr_callback):
+        """Run the optional OCR callback and pull the text input out."""
+        if ocr_callback is not None:
+            input_data = ocr_callback(file_path, input_data)
+        return input_data[0]["text_input"]
+
+    @staticmethod
+    def _extract_file_paths(input_data):
+        """Resolve absolute file paths from input data (matches ollama_inference)."""
+        return [
+            os.path.abspath(file_path)
+            for data in input_data
+            for file_path in data.get("file_path", [])
+        ]
+
+
+def _file_to_data_uri(path):
+    """Read a local image / PDF file and return a base64 data URI.
+
+    LiteLLM normalizes OpenAI-format ``image_url`` content blocks into each
+    upstream provider's native shape (Anthropic ``image`` blocks, Bedrock
+    ``image`` blocks, Vertex AI ``inlineData``, etc.), so a single data URI
+    works across providers.
+    """
+    mime, _ = mimetypes.guess_type(path)
+    if mime is None:
+        # Reasonable default for image files without a recognised extension.
+        mime = "image/png"
+    with open(path, "rb") as fh:
+        data = fh.read()
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
   
  Adds **LiteLLM as a vision-LLM backend** in `sparrow-parse`, registered as `method: "litellm"` in the existing `InferenceFactory`. It is *not* a proxy server. Sparrow imports the `litellm` SDK directly and      
  routes every inference call through `litellm.completion`, so a single backend can extract from images using OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Cohere, Mistral, Groq and 90+ other vision-capable hosted
   providers without adding each SDK separately.                                                                                                                                                                     
                  
  Use it like any other backend:                                                                                                                                                                                     
   
  ```python                                                                                                                                                                                                          
  from sparrow_parse.vlmb.inference_factory import InferenceFactory

  config = {
      "method": "litellm",
      "model_name": "anthropic/claude-3-5-sonnet-20241022",                                                                                                                                                          
      # Optional, leave unset to use ANTHROPIC_API_KEY env var:
      # "api_key": "sk-ant-...",                                                                                                                                                                                     
      # "api_base": "https://your-foundry-endpoint/anthropic",
      # "litellm_kwargs": {"num_retries": 3, "drop_params": True},                                                                                                                                                   
  }                                                                                                                                                                                                                  
  factory = InferenceFactory(config)                                                                                                                                                                                 
  backend = factory.get_inference_instance()                                                                                                                                                                         
                                                                                                                                                                                                                     
  results = backend.inference([{
      "file_path": ["images/receipt_00001.png"],                                                                                                                                                                     
      "text_input": 'Extract receipt fields. Return JSON with store_name and total.',                                                                                                                                
  }])                                                                                                                                                                                                                
```                                                                                                                                                                                                                     
  `drop_params=True` is on by default so `kwargs` that some providers reject (presence_penalty / frequency_penalty on Anthropic, Gemini, Bedrock; response_format on Bedrock; etc.) are silently dropped instead of      
  raising UnsupportedParamsError. Override via litellm_kwargs={"drop_params": False}.                                                                                                                                
                                                                                                                                                                                                                     
  Image inputs are converted to base64 data URIs and sent as OpenAI-format image_url content blocks. LiteLLM normalizes those to each upstream's native shape (Anthropic image blocks, Bedrock image blocks, Vertex  
  AI inlineData, etc.), so a single code path works across providers.                                                                                                                                                                                 
                  
  LiteLLM 1.60+ is required for drop_params support. The 1.85 cap leaves headroom for patch releases.                                                                                                                
   
  ## Files                                                                                                                                                                                                              
```bash                  
  - sparrow-data/parse/sparrow_parse/vlmb/litellm_inference.py (new, 238 LOC). LiteLLMInference(ModelInference) implementing inference() for both text-only and image paths over litellm.completion. Local helper    
  _file_to_data_uri builds the base64 data URI for cross-provider image normalization. The JSON-cleanup process_response mirrors the version in ollama_inference.py / vllm_inference.py.
  - sparrow-data/parse/sparrow_parse/vlmb/inference_factory.py (8 LOC). New elif self.config["method"] == "litellm" branch. Passes through optional api_key, api_base, litellm_kwargs config keys.                   
  - sparrow-data/parse/setup.py (4 LOC). New litellm extras entry pinned to litellm>=1.60,<1.85. Also added to the all extras bucket. Pattern matches the existing mlx, linux, all extras.                           
  - sparrow-data/parse/sparrow_parse/test_litellm_inference.py (290 LOC, new). 18 unit tests covering init, factory registration, mode dispatch, image data URI generation, multi-file resilience, JSON-cleanup      
  parity with sibling backends.                                                                                                                                                                                      
  - sparrow-data/parse/README.md. New "LiteLLM Backend (AI Gateway, 100+ hosted providers)" section between the Ollama and Hugging Face sections, plus an install instruction (pip install sparrow-parse[litellm])   
  and an env-var note in the Additional Requirements list.                                                                                                                                                           
                  
  ## Tests                                                                                                                                                                                                    

  $ pytest sparrow_parse/test_litellm_inference.py                                                                                                                                                                   
  ======================== 18 passed in 0.96s ========================
```
                                                                                                                                                                                                                     
  Tests cover init defaults (drop_params), factory dispatch, mode handling (static / text-only / image), image-to-data-URI generation including unknown-extension fallback, multi-file resilience (one image fails,  
  others succeed), and JSON cleanup parity with sibling backends.
                                                                                                                                                                                                                     
  Factory smoke test (no regression in unknown-method handling)                                                                                                                                                      

 ```python  
  from sparrow_parse.vlmb.inference_factory import InferenceFactory                                                                                                                                                  
  from sparrow_parse.vlmb.litellm_inference import LiteLLMInference                                                                                                                                                  
   
  # Unknown method still raises (existing behavior preserved)                                                                                                                                                        
  try:            
      InferenceFactory({"method": "nonexistent_backend_xyz"}).get_inference_instance()                                                                                                                               
  except ValueError as e:
      assert "Unknown method" in str(e)                                                                                                                                                                              
   
  # litellm method dispatches correctly                                                                                                                                                                              
  instance = InferenceFactory(
      {"method": "litellm", "model_name": "openai/gpt-4o"}
  ).get_inference_instance()                                                                                                                                                                                         
  assert isinstance(instance, LiteLLMInference)
  assert instance.model_name == "openai/gpt-4o"                                                                                                                                                                      
```                                                                                                                                                                                                                     
  Both assertions hold.
                                                                                                                                                                                                                     
  Live vision E2E (Anthropic Claude Sonnet 4-6 via Azure AI Foundry)                                                                                                                                                 
   
  Four scenarios verified end-to-end against a real provider, using the bundled sample images:                                                                                                                       
  ```bash                
  === Vision extraction :: anthropic/claude-sonnet-4-6 ===                                                                                                                                                           
                                                                                                                                                                                                                     
  [1] Receipt extraction (sparrow_parse/images/receipt_00001.png)                                                                                                                                                    
    query   : Extract receipt fields. Return JSON with: store_name, total.                                                                                                                                           
    output  : {                                                                                                                                                                                                      
                "store_name": "Unknown",                                                                                                                                                                             
                "total": 580965.0
              }                                                                                                                                                                                                      
    PASS (valid JSON, expected keys present)
                                                                                                                                                                                                                     
  [2] Bonds table extraction (sparrow_parse/images/bonds_table.png)                                                                                                                                                  
    query   : Extract bonds rows. JSON array with instrument_name and valuation.                                                                                                                                     
    output  : [                                                                                                                                                                                                      
                { 
                  "instrument_name": "UNITS BLACKROCK FIX INC DUB FDS PLC ISHS EUR INV GRD CP BD IDX/INST/E",                                                                                                        
                  "valuation": 19049                                                                                                                                                                                 
                },                                                                                                                                                                                                   
                {                                                                                                                                                                                                    
                  "instrument_name": "UNITS ISHARES III PLC CORE EUR GOVT BOND UCITS ETF/EUR",                                                                                                                       
                  "valuation": 83488                                                                                                                                                                                 
                },
                ...                                                                                                                                                                                                  
              ]   
    PASS (valid JSON array, expected keys present)
                                                                                                                                                                                                                     
  [3] Text-only inference (no file_path)
    query   : Reply with just '4'. What is 2+2?                                                                                                                                                                      
    output  : '4'                                                                                                                                                                                                    
    PASS                                                                                                                                                                                                             
                                                                                                                                                                                                                     
  [4] drop_params=True with presence_penalty=0.5                                                                                                                                                                     
    PASS (Anthropic accepted, presence_penalty silently dropped)
                                                                                                                                                                                                                     
  Reproduce                                                                                                                                                                                                          
                                                                                                                                                                                                                     
  pip install "sparrow-parse[litellm]"                                                                                                                                                                               
                  
  # Unit                                                                                                                                                                                                             
  cd sparrow-data/parse && python3 -m pytest sparrow_parse/test_litellm_inference.py
                                                                                                                                                                                                                     
  # Live (any LiteLLM-supported vision provider)
  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                
```

```python                                                                                                                                                                                                     
  from sparrow_parse.vlmb.inference_factory import InferenceFactory
                                                                                                                                                                                                                     
  cfg = {         
      'method': 'litellm',                                                                                                                                                                                           
      'model_name': 'anthropic/claude-3-5-sonnet-20241022',
  }
  backend = InferenceFactory(cfg).get_inference_instance()
  out = backend.inference([{                                                                                                                                                                                         
      'file_path': ['sparrow_parse/images/receipt_00001.png'],
      'text_input': 'Extract store_name and total. Return JSON.',                                                                                                                                                    
  }])             
  print(out[0])                                                                                                                                                                                                      
```